### PR TITLE
Swap the position of the Next and Previous buttons

### DIFF
--- a/UserDev/EventDisplay/python/gui/gui.py
+++ b/UserDev/EventDisplay/python/gui/gui.py
@@ -531,18 +531,18 @@ class gui(QtGui.QWidget):
     self._eventLabel = QtGui.QLabel("Event: 0")
     self._subrunLabel = QtGui.QLabel("Subrun: 0")
 
-    # Jump to the next event
-    self._nextButton = QtGui.QPushButton("Next")
-    self._nextButton.clicked.connect(self._event_manager.next)
-    self._nextButton.setToolTip("Move to the next event.")
     # Go to the previous event
     self._prevButton = QtGui.QPushButton("Previous")
     self._prevButton.clicked.connect(self._event_manager.prev)
     self._prevButton.setToolTip("Move to the previous event.")
-    # Pack Next and Previous in a horizontal layout
-    self._nextPreviousLayout = QtGui.QHBoxLayout()
-    self._nextPreviousLayout.addWidget(self._nextButton)
-    self._nextPreviousLayout.addWidget(self._prevButton)
+    # Jump to the next event
+    self._nextButton = QtGui.QPushButton("Next")
+    self._nextButton.clicked.connect(self._event_manager.next)
+    self._nextButton.setToolTip("Move to the next event.")
+    # Pack Previous and Next in a horizontal layout
+    self._previousNextLayout = QtGui.QHBoxLayout()
+    self._previousNextLayout.addWidget(self._prevButton)
+    self._previousNextLayout.addWidget(self._nextButton)
 
     # Select a file to use
     self._fileSelectButton = QtGui.QPushButton("Select File")
@@ -564,9 +564,9 @@ class gui(QtGui.QWidget):
     self._eventControlBox.addWidget(self._eventLabel)
     self._eventControlBox.addWidget(self._runLabel)
     self._eventControlBox.addWidget(self._subrunLabel)
-    # self._eventControlBox.addWidget(self._nextButton)
     # self._eventControlBox.addWidget(self._prevButton)
-    self._eventControlBox.addLayout(self._nextPreviousLayout)
+    # self._eventControlBox.addWidget(self._nextButton)
+    self._eventControlBox.addLayout(self._previousNextLayout)
     self._eventControlBox.addWidget(self._fileSelectButton)
 
     return self._eventControlBox
@@ -1121,11 +1121,11 @@ class gui(QtGui.QWidget):
     self._view_manager.setRangeToMax()
 
   def keyPressEvent(self,e):
-    if e.key() == QtCore.Qt.Key_N:
-      self._event_manager.next()
-      return
     if e.key() == QtCore.Qt.Key_P:
       self._event_manager.prev()
+      return
+    if e.key() == QtCore.Qt.Key_N:
+      self._event_manager.next()
       return
     if e.key() == QtCore.Qt.Key_C:
       # print "C was pressed"

--- a/UserDev/EventDisplay/python/gui/gui3D.py
+++ b/UserDev/EventDisplay/python/gui/gui3D.py
@@ -173,15 +173,15 @@ class gui3D(QtGui.QWidget):
     self._eventLabel = QtGui.QLabel("Ev.: 0")
     self._subrunLabel = QtGui.QLabel("Subrun: 0")
 
+    # Go to the previous event
+    self._prevButton = QtGui.QPushButton("Previous")
+    self._prevButton.clicked.connect(self._event_manager.prev)
+    self._prevButton.setToolTip("Move to the previous event.")
     # Jump to the next event
     self._nextButton = QtGui.QPushButton("Next")
     # self._nextButton.setStyleSheet("background-color: red")
     self._nextButton.clicked.connect(self._event_manager.next)
     self._nextButton.setToolTip("Move to the next event.")
-    # Go to the previous event
-    self._prevButton = QtGui.QPushButton("Previous")
-    self._prevButton.clicked.connect(self._event_manager.prev)
-    self._prevButton.setToolTip("Move to the previous event.")
     # Select a file to use
     self._fileSelectButton = QtGui.QPushButton("Select File")
     self._fileSelectButton.clicked.connect(self._event_manager.selectFile)
@@ -202,8 +202,8 @@ class gui3D(QtGui.QWidget):
     self._eventControlBox.addWidget(self._eventLabel)
     self._eventControlBox.addWidget(self._runLabel)
     self._eventControlBox.addWidget(self._subrunLabel)
-    self._eventControlBox.addWidget(self._nextButton)
     self._eventControlBox.addWidget(self._prevButton)
+    self._eventControlBox.addWidget(self._nextButton)
     self._eventControlBox.addWidget(self._fileSelectButton)
 
     return self._eventControlBox
@@ -495,11 +495,11 @@ class gui3D(QtGui.QWidget):
     self._view_manager.setRangeToMax()
 
   def keyPressEvent(self,e):
-    if e.key() == QtCore.Qt.Key_N:
-      self._event_manager.next()
-      return
     if e.key() == QtCore.Qt.Key_P:
       self._event_manager.prev()
+      return
+    if e.key() == QtCore.Qt.Key_N:
+      self._event_manager.next()
       return
     if e.key() == QtCore.Qt.Key_C:
       # print "C was pressed"


### PR DESCRIPTION
It feels more natural to have Previous on the left and Next on the right. I guess I'm conditioned from web browsers. 