### PR TITLE
Bug fix for hits drawn on wire drawing

### DIFF
--- a/UserDev/EventDisplay/python/evdmanager/evdmanager.py
+++ b/UserDev/EventDisplay/python/evdmanager/evdmanager.py
@@ -671,17 +671,18 @@ class evd_manager_2D(evd_manager_base):
         else:
             return False
 
-    def drawHitsOnWire(self, plane, wire):
+    def drawHitsOnWire(self, plane, wire, tpc):
         if not 'Hit' in self._drawnClasses:
             return
         else:
-            # Get the hits:
-            hits = self._drawnClasses['Hit'].getHitsOnWire(plane, wire)
-            self._view_manager.drawHitsOnPlot(hits)
+            # Get the right plane number
+            this_plane = plane
+            if tpc == 1:
+                this_plane = self._geom.planeMix()[plane][0]
 
-            if self._geom.nTPCs() == 2:
-                hits = self._drawnClasses['Hit'].getHitsOnWire(plane + self._geom.nPlanes(), wire)
-                self._view_manager.drawHitsOnPlot(hits, flip=True)
+            # Get the hits:
+            hits = self._drawnClasses['Hit'].getHitsOnWire(this_plane, wire)
+            self._view_manager.drawHitsOnPlot(hits)
 
 
 try:

--- a/UserDev/EventDisplay/python/gui/gui.py
+++ b/UserDev/EventDisplay/python/gui/gui.py
@@ -32,7 +32,7 @@ class VerticalLabel(QtGui.QLabel):
 class view_manager(QtCore.QObject):
   """This class manages a collection of viewports"""
 
-  drawHitsRequested = QtCore.pyqtSignal(int, int)
+  drawHitsRequested = QtCore.pyqtSignal(int, int, int)
 
   def __init__(self, geometry):
     super(view_manager, self).__init__()
@@ -138,14 +138,14 @@ class view_manager(QtCore.QObject):
     for view in self._drawerList.values():
       view.clearPoints()
 
-  def hitOnWireHandler(self,plane,wire):
+  def hitOnWireHandler(self, plane, wire, tpc):
     if not self._wireDrawer.isVisible():
       return
     # Simply pass the info on to who ever is listening
     # (hint: it's the manager)
     for hit in self._plottedHits:
       self._wirePlot.removeItem(hit)
-    self.drawHitsRequested.emit(plane,wire)
+    self.drawHitsRequested.emit(plane, wire, tpc)
 
   def getDrawListWidget(self):
 

--- a/UserDev/EventDisplay/python/gui/viewport.py
+++ b/UserDev/EventDisplay/python/gui/viewport.py
@@ -22,7 +22,7 @@ class VerticalLabel(QtGui.QLabel):
 
 class viewport(pg.GraphicsLayoutWidget):
 
-  drawHitsRequested = QtCore.pyqtSignal(int, int)
+  drawHitsRequested = QtCore.pyqtSignal(int, int, int)
 
   def customMouseDragEvent(self, ev, axis=None):
     '''
@@ -505,7 +505,7 @@ class viewport(pg.GraphicsLayoutWidget):
         self._wdf(wireData=self._wireData, wire=wire, plane=self._plane , tpc=tpc, cryo=self._cryostat, drawer=self)
 
     # Make a request to draw the hits from this wire:
-    self.drawHitsRequested.emit(self._plane,wire)
+    self.drawHitsRequested.emit(self._plane, wire, tpc)
 
 
   def connectWireDrawingFunction(self,func):


### PR DESCRIPTION
Fixing bug on hit displayed on wire drawing. Before, hits from two planes were displayed on the same wire. This artifact has now been removed.