### PR TITLE
Memory Leak Fix

### DIFF
--- a/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.cxx
+++ b/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.cxx
@@ -35,11 +35,11 @@ bool DrawOpDetWaveform::initialize() {
   return true;
 }
 
-bool DrawOpDetWaveform::analyze(gallery::Event * ev) {
+bool DrawOpDetWaveform::analyze(const gallery::Event & ev) {
 
   art::InputTag op_wvf_tag(_producer);
   auto const & op_wvfs
-    = ev -> getValidHandle<std::vector <raw::OpDetWaveform> >(op_wvf_tag);
+    = ev.getValidHandle<std::vector <raw::OpDetWaveform> >(op_wvf_tag);
 
   std::cout << "OpDetWaveform analyze, op_wvfs size: " << op_wvfs->size() << std::endl;
 

--- a/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
+++ b/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
@@ -64,7 +64,7 @@ namespace evd {
     /** IMPLEMENT in DrawOpDetWaveform.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event * event);
+    virtual bool analyze(const gallery::Event & event);
 
     /** IMPLEMENT in DrawOpDetWaveform.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RawViewer/DrawRawDigit.cxx
+++ b/UserDev/EventDisplay/RawViewer/DrawRawDigit.cxx
@@ -49,7 +49,7 @@ bool DrawRawDigit::initialize() {
   return true;
 }
 
-bool DrawRawDigit::analyze(gallery::Event *ev) {
+bool DrawRawDigit::analyze(const gallery::Event &ev) {
   //
   // Do your event-by-event analysis here. This function is called for
   // each event in the loop. You have "storage" pointer which contains
@@ -78,13 +78,13 @@ bool DrawRawDigit::analyze(gallery::Event *ev) {
   if (_producer != "") {
     std::cout << "Drawing RawDigits using producer " << _producer << std::endl;
     art::InputTag wires_tag(_producer);
-    auto const & raw_digits = ev->getValidHandle<std::vector<raw::RawDigit>>(wires_tag);
+    auto const & raw_digits = ev.getValidHandle<std::vector<raw::RawDigit>>(wires_tag);
     raw_digits_v.push_back(raw_digits);
   } else {
     for (auto p : _producers) {
       std::cout << "Drawing RawDigits using producer " << p << std::endl;
       art::InputTag wires_tag(p);
-      auto const & raw_digits = ev->getValidHandle<std::vector<raw::RawDigit>>(wires_tag);
+      auto const & raw_digits = ev.getValidHandle<std::vector<raw::RawDigit>>(wires_tag);
       raw_digits_v.push_back(raw_digits);
     }
   }

--- a/UserDev/EventDisplay/RawViewer/DrawRawDigit.h
+++ b/UserDev/EventDisplay/RawViewer/DrawRawDigit.h
@@ -52,7 +52,7 @@ public:
     /** IMPLEMENT in DrawRawDigit.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event * event);
+    virtual bool analyze(const gallery::Event &event);
 
     /** IMPLEMENT in DrawRawDigit.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RawViewer/DrawWire.cxx
+++ b/UserDev/EventDisplay/RawViewer/DrawWire.cxx
@@ -47,7 +47,7 @@ bool DrawWire::initialize() {
 
 }
 
-bool DrawWire::analyze(gallery::Event * ev) {
+bool DrawWire::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -79,13 +79,13 @@ bool DrawWire::analyze(gallery::Event * ev) {
   if (_producer != "") {
     std::cout << "Drawing Wires using producer " << _producer << std::endl;
     art::InputTag wires_tag(_producer);
-    auto const & wires = ev->getValidHandle<std::vector<recob::Wire>>(wires_tag);
+    auto const & wires = ev.getValidHandle<std::vector<recob::Wire>>(wires_tag);
     wire_v.push_back(wires);
   } else {
     for (auto p : _producers) {
       std::cout << "Drawing Wires using producer " << p << std::endl;
       art::InputTag wires_tag(p);
-      auto const & wires = ev->getValidHandle<std::vector<recob::Wire>>(wires_tag);
+      auto const & wires = ev.getValidHandle<std::vector<recob::Wire>>(wires_tag);
       wire_v.push_back(wires);
     }
   }

--- a/UserDev/EventDisplay/RawViewer/DrawWire.h
+++ b/UserDev/EventDisplay/RawViewer/DrawWire.h
@@ -51,7 +51,7 @@ namespace evd {
     /** IMPLEMENT in DrawWire.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event * event);
+    virtual bool analyze(const gallery::Event & event);
 
     /** IMPLEMENT in DrawWire.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawCluster.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawCluster.cxx
@@ -33,7 +33,7 @@ bool DrawCluster::initialize() {
   return true;
 }
 
-bool DrawCluster::analyze(gallery::Event * ev) {
+bool DrawCluster::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -71,7 +71,7 @@ bool DrawCluster::analyze(gallery::Event * ev) {
   // Get all of the clusters from the event:
   art::InputTag clusters_tag(_producer);
   auto const & clusters
-    = ev -> getValidHandle<std::vector <recob::Cluster> >(clusters_tag);
+    = ev.getValidHandle<std::vector <recob::Cluster> >(clusters_tag);
 
   if (clusters->size() == 0) {
     std::cout << "No clusters found." << std::endl;
@@ -83,7 +83,7 @@ bool DrawCluster::analyze(gallery::Event * ev) {
 
   art::InputTag assn_tag(_producer);
 
-  art::FindMany<recob::Hit> hits_for_cluster(clusters, *ev, assn_tag);
+  art::FindMany<recob::Hit> hits_for_cluster(clusters, ev, assn_tag);
 
 
 

--- a/UserDev/EventDisplay/RecoViewer/DrawCluster.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawCluster.h
@@ -60,7 +60,7 @@ public:
   /** IMPLEMENT in DrawCluster.cc!
       Analyze a data event-by-event
   */
-  virtual bool analyze(gallery::Event * event);
+  virtual bool analyze(const gallery::Event & event);
 
   /** IMPLEMENT in DrawCluster.cc!
       Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawEndpoint.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawEndpoint.cxx
@@ -29,7 +29,7 @@ bool DrawEndpoint::initialize() {
   return true;
 }
 
-bool DrawEndpoint::analyze(gallery::Event * ev) {
+bool DrawEndpoint::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -57,7 +57,7 @@ bool DrawEndpoint::analyze(gallery::Event * ev) {
 
   art::InputTag end2d_tag(_producer);
   auto const & end2dHandle
-        = ev -> getValidHandle<std::vector <recob::EndPoint2D> >(end2d_tag);
+        = ev.getValidHandle<std::vector <recob::EndPoint2D> >(end2d_tag);
 
 
 

--- a/UserDev/EventDisplay/RecoViewer/DrawEndpoint.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawEndpoint.h
@@ -70,7 +70,7 @@ public:
   /** IMPLEMENT in DrawEndpoint.cc!
       Analyze a data event-by-event
   */
-  virtual bool analyze(gallery::Event * event);
+  virtual bool analyze(const gallery::Event & event);
 
   /** IMPLEMENT in DrawEndpoint.cc!
       Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawHit.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawHit.cxx
@@ -25,7 +25,7 @@ bool DrawHit::initialize() {
   return true;
 }
 
-bool DrawHit::analyze(gallery::Event* ev) {
+bool DrawHit::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -49,7 +49,7 @@ bool DrawHit::analyze(gallery::Event* ev) {
 
   art::InputTag hits_tag(_producer);
   auto const & hitHandle
-        = ev -> getValidHandle<std::vector <recob::Hit> >(hits_tag);
+        = ev.getValidHandle<std::vector <recob::Hit> >(hits_tag);
 
 
   // Clear out the hit data but reserve some space for the hits

--- a/UserDev/EventDisplay/RecoViewer/DrawHit.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawHit.h
@@ -92,7 +92,7 @@ public:
     /** IMPLEMENT in DrawCluster.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event* event);
+    virtual bool analyze(const gallery::Event & event);
 
     /** IMPLEMENT in DrawCluster.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawMCTrack.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTrack.cxx
@@ -48,7 +48,7 @@ bool DrawMCTrack::initialize() {
   return true;
 }
 
-bool DrawMCTrack::analyze(gallery::Event *ev) {
+bool DrawMCTrack::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -72,7 +72,7 @@ bool DrawMCTrack::analyze(gallery::Event *ev) {
   // get a handle to the tracks
   art::InputTag tracks_tag(_producer);
   auto const &trackHandle =
-      ev->getValidHandle<std::vector<sim::MCTrack>>(tracks_tag);
+      ev.getValidHandle<std::vector<sim::MCTrack>>(tracks_tag);
 
   // Clear out the data but reserve some space for the tracks
   for (unsigned int p = 0; p < total_plane_number; p++) {

--- a/UserDev/EventDisplay/RecoViewer/DrawMCTrack.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTrack.h
@@ -65,7 +65,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event *event);
+  virtual bool analyze(const gallery::Event & event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawMCTruth.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTruth.cxx
@@ -19,11 +19,11 @@ bool DrawMCTruth::initialize() {
   return true;
 }
 
-bool DrawMCTruth::analyze(gallery::Event *ev) {
+bool DrawMCTruth::analyze(const gallery::Event & ev) {
 
   art::InputTag truth_tag(_producer);
   auto const &truthHandle =
-      ev->getValidHandle<std::vector<simb::MCTruth>>(truth_tag);
+      ev.getValidHandle<std::vector<simb::MCTruth>>(truth_tag);
 
   _data.clear();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawMCTruth.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTruth.h
@@ -69,7 +69,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event *event);
+  virtual bool analyze(const gallery::Event & event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawNumuSelection.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawNumuSelection.cxx
@@ -79,7 +79,7 @@ bool DrawNumuSelection::initialize() {
   return true;
 }
 
-bool DrawNumuSelection::analyze(gallery::Event *ev) {
+bool DrawNumuSelection::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -108,7 +108,7 @@ bool DrawNumuSelection::analyze(gallery::Event *ev) {
   tracks.clear();
 
   auto const &assoc_handle =
-      ev->getValidHandle<art::Assns<recob::Vertex, recob::Track>>(_producer);
+      ev.getValidHandle<art::Assns<recob::Vertex, recob::Track>>(_producer);
 
   if (assoc_handle->size() == 0)
     return true; // no selected neutrino in this event

--- a/UserDev/EventDisplay/RecoViewer/DrawNumuSelection.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawNumuSelection.h
@@ -64,7 +64,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event *event);
+  virtual bool analyze(const gallery::Event & event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawOpflash.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawOpflash.cxx
@@ -27,7 +27,7 @@ bool DrawOpflash::initialize() {
   return true;
 }
 
-bool DrawOpflash::analyze(gallery::Event *ev) {
+bool DrawOpflash::analyze(const gallery::Event & ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -49,12 +49,12 @@ bool DrawOpflash::analyze(gallery::Event *ev) {
 
   art::InputTag opflash_tag(_producer);
   auto const & opflashHandle
-        = ev -> getValidHandle<std::vector <recob::OpFlash> >(opflash_tag);
+        = ev.getValidHandle<std::vector <recob::OpFlash> >(opflash_tag);
 
   // Retrieve the ophits to infer the plane the opflash belongs to
   try {
     art::InputTag assn_tag(_producer);
-    art::FindMany<recob::OpHit> flash_to_hits(opflashHandle, *ev, assn_tag);
+    art::FindMany<recob::OpHit> flash_to_hits(opflashHandle, ev, assn_tag);
 
     size_t total_plane_number = _geo_service.NTPC() * _geo_service.Ncryostats();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawOpflash.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawOpflash.h
@@ -72,7 +72,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event *event);
+  virtual bool analyze(const gallery::Event & event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawShower.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawShower.cxx
@@ -27,7 +27,7 @@ bool DrawShower::initialize() {
 
 }
 
-bool DrawShower::analyze(gallery::Event * ev) {
+bool DrawShower::analyze(const gallery::Event & ev) {
 
   size_t total_plane_number = _geo_service.Nplanes() * _geo_service.NTPC() * _geo_service.Ncryostats();
 
@@ -35,7 +35,7 @@ bool DrawShower::analyze(gallery::Event * ev) {
   // get a handle to the showers
   art::InputTag shower_tag(_producer);
   auto const & showerHandle
-    = ev -> getValidHandle<std::vector <recob::Shower> >(shower_tag);
+    = ev.getValidHandle<std::vector <recob::Shower> >(shower_tag);
 
 
   if (showerHandle -> size() == 0) {
@@ -47,7 +47,7 @@ bool DrawShower::analyze(gallery::Event * ev) {
 
   // Retrieve the hits to infer the TPC the track belongs to
   art::InputTag assn_tag(_producer);
-  art::FindMany<recob::Hit> shower_to_hits(showerHandle, *ev, assn_tag);
+  art::FindMany<recob::Hit> shower_to_hits(showerHandle, ev, assn_tag);
 
 
   // Clear out the hit data but reserve some space for the showers

--- a/UserDev/EventDisplay/RecoViewer/DrawShower.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawShower.h
@@ -89,7 +89,7 @@ public:
     /** IMPLEMENT in DrawCluster.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event * event);
+    virtual bool analyze(const gallery::Event & event);
 
     /** IMPLEMENT in DrawCluster.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawSpacepoint.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawSpacepoint.cxx
@@ -25,7 +25,7 @@ bool DrawSpacepoint::initialize() {
   return true;
 }
 
-bool DrawSpacepoint::analyze(gallery::Event * ev) {
+bool DrawSpacepoint::analyze(const gallery::Event & ev) {
   size_t total_plane_number = _geo_service.Nplanes() * _geo_service.NTPC() * _geo_service.Ncryostats();
   larutil::SimpleGeometryHelper geo_helper(_geo_service, _det_prop, _det_clock);
 
@@ -34,7 +34,7 @@ bool DrawSpacepoint::analyze(gallery::Event * ev) {
   // get a handle to the tracks
   art::InputTag sps_tag(_producer);
   auto const & spacepointHandle
-        = ev -> getValidHandle<std::vector <recob::SpacePoint> >(sps_tag);
+        = ev.getValidHandle<std::vector <recob::SpacePoint> >(sps_tag);
 
   // geoHelper = larutil::GeometryHelper::GetME();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawSpacepoint.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawSpacepoint.h
@@ -50,7 +50,7 @@ public:
     /** IMPLEMENT in DrawCluster.cc!
         Analyze a data event-by-event
     */
-    virtual bool analyze(gallery::Event * event);
+    virtual bool analyze(const gallery::Event &event);
 
     /** IMPLEMENT in DrawCluster.cc!
         Finalize method to be called after all events processed.

--- a/UserDev/EventDisplay/RecoViewer/DrawTrack.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawTrack.cxx
@@ -52,7 +52,7 @@ bool DrawTrack::initialize() {
   return true;
 }
 
-bool DrawTrack::analyze(gallery::Event *ev) {
+bool DrawTrack::analyze(const gallery::Event &ev) {
 
   //
   // Do your event-by-event analysis here. This function is called for
@@ -74,7 +74,7 @@ bool DrawTrack::analyze(gallery::Event *ev) {
   // get a handle to the tracks
   art::InputTag tracks_tag(_producer);
   auto const &trackHandle =
-      ev->getValidHandle<std::vector<recob::Track>>(tracks_tag);
+      ev.getValidHandle<std::vector<recob::Track>>(tracks_tag);
 
   // Clear out the data but reserve some space for the tracks
   for (unsigned int p = 0; p < _total_plane_number; p++) {
@@ -88,7 +88,7 @@ bool DrawTrack::analyze(gallery::Event *ev) {
 
   // Retrieve the hits to infer the TPC the track belongs to
   art::InputTag assn_tag(_producer);
-  art::FindMany<recob::Hit> track_to_hits(trackHandle, *ev, assn_tag);
+  art::FindMany<recob::Hit> track_to_hits(trackHandle, ev, assn_tag);
 
   // Populate the track vector:
   size_t index = 0;

--- a/UserDev/EventDisplay/RecoViewer/DrawTrack.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawTrack.h
@@ -66,7 +66,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event *event);
+  virtual bool analyze(const gallery::Event &event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/RecoViewer/DrawVertex.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawVertex.cxx
@@ -31,7 +31,7 @@ bool DrawVertex::initialize() {
 
 }
 
-bool DrawVertex::analyze(gallery::Event * ev) {
+bool DrawVertex::analyze(const gallery::Event & ev) {
 
   larutil::SimpleGeometryHelper geo_helper(_geo_service, _det_prop, _det_clock);
 
@@ -39,7 +39,7 @@ bool DrawVertex::analyze(gallery::Event * ev) {
 
   art::InputTag vertex_tag(_producer);
   auto const & vertexHandle
-        = ev -> getValidHandle<std::vector <recob::Vertex> >(vertex_tag);
+        = ev.getValidHandle<std::vector <recob::Vertex> >(vertex_tag);
 
 
 

--- a/UserDev/EventDisplay/RecoViewer/DrawVertex.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawVertex.h
@@ -44,7 +44,7 @@ public:
 
   virtual bool initialize();
 
-  virtual bool analyze(gallery::Event * event);
+  virtual bool analyze(const gallery::Event & event);
 
   virtual bool finalize();
 

--- a/UserDev/EventDisplay/python/evdmanager/liveevdmanager.py
+++ b/UserDev/EventDisplay/python/evdmanager/liveevdmanager.py
@@ -1,4 +1,9 @@
+import os
+
 from pyqtgraph.Qt import QtCore
+
+from ROOT import gallery
+from ROOT import TFile
 
 try:
   from event import manager, event
@@ -8,10 +13,8 @@ except ImportError:
   from evdmanager.evdmanager import evd_manager_base
 
 import datatypes
-from ROOT import gallery
-import os
-from ROOT import TFile
-import ROOT
+
+# import ROOT
 
 class live_evd_manager_2D(evd_manager_base):
 
@@ -40,7 +43,7 @@ class live_evd_manager_2D(evd_manager_base):
             self._drawnClasses[informal_type].setProducer(product.fullName())
             self.processEvent(True)
             self._drawnClasses[informal_type].clearDrawnObjects(self._view_manager)
-            if informal_type == 'MCTrack' or informal_type == 'Track': 
+            if informal_type == 'MCTrack' or informal_type == 'Track':
                 self._drawnClasses[informal_type].drawObjects(self._view_manager, self._gui._tracksOnBothTPCs)
             else:
                 self._drawnClasses[informal_type].drawObjects(self._view_manager)
@@ -70,7 +73,7 @@ class live_evd_manager_2D(evd_manager_base):
             self._drawnClasses.update({informal_type: drawingClass})
             # Need to process the event
             self.processEvent(True)
-            if informal_type == 'MCTrack' or informal_type == 'Track': 
+            if informal_type == 'MCTrack' or informal_type == 'Track':
                 drawingClass.drawObjects(self._view_manager, self._gui._tracksOnBothTPCs)
             else:
                 drawingClass.drawObjects(self._view_manager)

--- a/UserDev/EventDisplay/python/gui/gui.py
+++ b/UserDev/EventDisplay/python/gui/gui.py
@@ -342,7 +342,7 @@ class view_manager(QtCore.QObject):
     if event_manager.hasOpDetWvfData():
       self._opt_view.drawOpDetWvf(event_manager.getOpDetWvf())
 
- 
+
   def drawWireOnPlot(self, wireData, wire=None, plane=None, tpc=None, cryo=None, drawer=None):
     # Need to draw a wire on the wire view
     # Don't bother if the view isn't active:
@@ -495,7 +495,7 @@ class gui(QtGui.QWidget):
     self._view_manager.drawHitsRequested.connect(self._event_manager.drawHitsOnWire)
 
   def closeEvent(self, event):
-    self.quit()  
+    self.quit()
 
   def quit(self):
     # if self._running:
@@ -503,8 +503,10 @@ class gui(QtGui.QWidget):
     QtCore.QCoreApplication.instance().quit()
 
 
-  def update(self):
-    # set the text boxes correctly:
+  def update_event_labels(self):
+    '''
+    Sets the text boxes correctly
+    '''
     self._larliteEventEntry.setText(str(self._event_manager.internalEvent()))
 
     eventLabel = "Event: " + str(self._event_manager.event())
@@ -513,6 +515,12 @@ class gui(QtGui.QWidget):
     self._runLabel.setText(runLabel)
     subrunLabel = "Subrun: " + str(self._event_manager.subrun())
     self._subrunLabel.setText(subrunLabel)
+    self.setupEventRunSubrun()
+
+
+  def update(self):
+    # set the text boxes correctly:
+    self.update_event_labels()
 
     self._view_manager.drawPlanes(self._event_manager)
     self._view_manager.drawOpDetWvf(self._event_manager)

--- a/UserDev/EventDisplay/python/gui/livegui.py
+++ b/UserDev/EventDisplay/python/gui/livegui.py
@@ -29,7 +29,7 @@ class livegui(gui):
 
         self._stage = None
         self._event_manager.fileChanged.connect(self.drawableProductsChanged)
-        self._event_manager.eventChanged.connect(self.update)
+        self._event_manager.eventChanged.connect(self.update_event_labels)
 
         self._app = app
 
@@ -275,7 +275,7 @@ class livegui(gui):
         # self._eastWidget.close()
         # east = self.getEastLayout()
         # self.slave.addWidget(east)
-        self.update()
+        # self.update()
         self.repaint()
 
 

--- a/UserDev/EventDisplay/python/gui/viewport.py
+++ b/UserDev/EventDisplay/python/gui/viewport.py
@@ -656,7 +656,7 @@ class viewport(pg.GraphicsLayoutWidget):
         #              max_wire - line_width/2,
         #              self._geometry.cathodeGap() - line_width/2)
         line.setRect(max_wire / 2 - self._geometry.cathodeGap() / 2 + line_width/2,
-                     0 + line_width/2, 
+                     0 + line_width/2,
                      self._geometry.cathodeGap(),
                      self._geometry.tRange() * 2 + self._geometry.cathodeGap()  - line_width/2)
         self._view.addItem(line)


### PR DESCRIPTION
This PR fixes a memory leak with the event display that was found when running TITUSLive during ICARUS operations.
Every time a new file was opened, the memory bumped up by 0.5 GB. This happened because the gallery::Event was passed to the ana unit class via a pointer, which was not collected by the garbage collector. The pointer has been switched to a const reference, which fixes the leak.


Current memory profile (memory sampled every 0.1 s):

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/17006198/106549723-2f586300-64d7-11eb-8a63-0d030f5212ec.png">

The three spikes happen when the file changes. The memory usage remains the same after a new file is opened.