### PR TITLE
Remove hardcoded time ranges from SBND geometry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Generic badge](https://img.shields.io/badge/DOI-10.3390/instruments4040031-green.svg)](https://doi.org/10.3390/instruments4040031)
+[![](https://img.shields.io/github/v/release/TITUS-EVD/gallery-framework?include_prereleases)](https://github.com/TITUS-EVD/gallery-framework/releases)
+[![](https://img.shields.io/github/commits-since/TITUS-EVD/gallery-framework/latest/master)](https://github.com/TITUS-EVD/gallery-framework/commits/master)
+
+
 # Gallery Framework
 
 
@@ -57,3 +62,5 @@ This framework contains TITUS: the event display for SBND at Fermilab. TITUS all
 4) Run with `evd.py /path/to/art-root-file.root`. Add option `-s` to use the SBND geometry. Add option `-i` to use the ICARUS geometry.
 
 If you have already built the evd, you can set it up by simply running `source config/setup_evd.sh`
+   
+

--- a/UserDev/EventDisplay/python/datatypes/mctrack.py
+++ b/UserDev/EventDisplay/python/datatypes/mctrack.py
@@ -29,6 +29,8 @@ class mctrack(recoBase):
                 points = []
                 # Remeber - everything is in cm, but the display is in
                 # wire/time!
+                if len(track.track()) > 0:
+                    print('MCTrack', i, 'start:', track.track()[0].first, track.track()[0].second)
                 for pair in track.track():
                     x = pair.first / geom.wire2cm()
                     y = pair.second / geom.time2cm() + offset

--- a/UserDev/EventDisplay/python/evd.py
+++ b/UserDev/EventDisplay/python/evd.py
@@ -55,6 +55,9 @@ def main():
     geom.add_argument('-S3', '-s3', '--sbnd3',
                       action='store_true',
                       help="Run with the SBND Geometry with 3 drift windows")
+    geom.add_argument('-S1', '-s1', '--sbnd1',
+                      action='store_true',
+                      help="Run with the SBND Geometry with 1 drift window")
     geom.add_argument('-I', '-i', '--icarus',
                       action='store_true',
                       help="Run with the ICARUS Geometry")
@@ -110,6 +113,11 @@ def main():
         geom._triggerOffset = 2500
         geom._readoutWindowSize = 7500
         geom.recalculateOffsets()
+    elif args.sbnd1:
+        geom = geometry.sbnd(geometryCore,detProperties,detClocks,lar_properties)
+        geom._tRange = 3000
+        geom._triggerOffset = 0
+        geom._readoutWindowSize = 3000
     elif args.icarus:
         geom = geometry.icarus(geometryCore,detProperties,detClocks,lar_properties,args.no_split_wire)
     else:

--- a/UserDev/EventDisplay/python/evdmanager/evdmanager.py
+++ b/UserDev/EventDisplay/python/evdmanager/evdmanager.py
@@ -204,8 +204,6 @@ class evd_manager_base(manager, QtCore.QObject):
         # what data products are available
 
         # Open the file
-        print(file)
-        print(type(file))
         f = TFile(file)
         e = f.Get("Events")
 
@@ -320,8 +318,7 @@ class evd_manager_base(manager, QtCore.QObject):
 
         # Have to figure out number of events available
         for _f in _file_list:
-            _f = str(_f)
-            _rf = TFile(_f)
+            _rf = TFile(str(_f))
             _tree = _rf.Get("Events")
             self._n_entries += _tree.GetEntries()
             _rf.Close()

--- a/UserDev/EventDisplay/python/evdmanager/geometry.py
+++ b/UserDev/EventDisplay/python/evdmanager/geometry.py
@@ -336,7 +336,7 @@ class geometry(geoBase):
         self._nCryos = int(geometryCore.Ncryostats())
         self._tRange = self._detectorProperties.NumberTimeSamples()
         self._readoutWindowSize = self._detectorProperties.NumberTimeSamples()
-        #self._triggerOffset = detProperties.TriggerOffset()
+        # self._triggerOffset = self._detectorClocks.TriggerOffsetTPC()
         self._triggerOffset = self._detectorClocks.TPCClock().Ticks(self._detectorClocks.TriggerOffsetTPC() * -1.)
 
         self._wRange = []
@@ -363,6 +363,11 @@ class geometry(geoBase):
 
             # print ('opch', opch, 'shape', geometryCore.OpDetGeoFromOpChannel(opch).Shape().IsA().GetName())
             # self._opdet_radius = geometryCore.OpDetGeoFromOpChannel(opch).RMax()
+
+        print('Configured with:')
+        print('\tTrigger Offset TPC:', self._triggerOffset)
+        print('\tTime Range:', self._tRange)
+        print('\tReadout Window Size:', self._readoutWindowSize)
 
     def recalculateOffsets(self):
         self._offset = []
@@ -411,9 +416,9 @@ class sbnd(geometry):
         from .mapping import sbnd_opdet_map
         self._opdet_radius = 6
         self._opdet_name = sbnd_opdet_map
-        self._tRange = 3000 #7500
-        self._triggerOffset = 0 #2500
-        self._readoutWindowSize = 3000 #7500
+        # self._tRange = 3000 #7500
+        # self._triggerOffset = 0 #2500
+        # self._readoutWindowSize = 3000 #7500
         self._planeOriginX = [0.0, -0.3, -0.6, 0.0, -0.3, -0.6]
         self._planeOriginXTicks = [0.0, -0.3/self._time2Cm, -0.6/self._time2Cm, 0.0, -0.3/self._time2Cm, -0.6/self._time2Cm]
         self._cathodeGap = 8.5 / self._time2Cm # 5.3 cm   # 100

--- a/UserDev/EventDisplay/python/gui/gui.py
+++ b/UserDev/EventDisplay/python/gui/gui.py
@@ -364,7 +364,7 @@ class view_manager(QtCore.QObject):
       self.plotFFT()
 
       # Store the viewport that just draw this
-      # as we might need it to increase and 
+      # as we might need it to increase and
       # decrease the displayed wire
       self._current_wire_drawer = drawer
       self._current_wire = wire

--- a/UserDev/EventDisplay/python/gui/viewport.py
+++ b/UserDev/EventDisplay/python/gui/viewport.py
@@ -495,6 +495,13 @@ class viewport(pg.GraphicsLayoutWidget):
     self.show_waveform(wire=wire, tpc=tpc)
 
   def show_waveform(self, wire, tpc):
+    '''
+    Shows the waveform on the wire drawer.
+
+    Args:
+        wire (int): The wire number
+        tpc (int): The TPC number where the wire belongs to
+    '''
 
     if self._item.image is not None:
       # get the data from the plot:
@@ -502,7 +509,16 @@ class viewport(pg.GraphicsLayoutWidget):
       if wire < len(data):
         self._wireData = data[wire]
         self._wireData = self._wireData[self._first_entry:self._last_entry]
-        self._wdf(wireData=self._wireData, wire=wire, plane=self._plane , tpc=tpc, cryo=self._cryostat, drawer=self)
+
+        # Here we want to display the real plane number, not the view.
+        # So, make sure that if you are in an odd TPC we display the right number.
+        plane = self._plane
+        if tpc %2 != 0:
+            if self._plane == 0:
+                plane = 1
+            elif self._plane == 1:
+                plane = 0
+        self._wdf(wireData=self._wireData, wire=wire, plane=plane, tpc=tpc, cryo=self._cryostat, drawer=self)
 
     # Make a request to draw the hits from this wire:
     self.drawHitsRequested.emit(self._plane, wire, tpc)


### PR DESCRIPTION
This PR:
- removes hardcoded values in SBND geometry configuration
- adds a configuration to run over files produced with 1 drift window