### PR TITLE
CRT Raw Updates

### DIFF
--- a/UserDev/EventDisplay/RawViewer/DrawFEBData.cxx
+++ b/UserDev/EventDisplay/RawViewer/DrawFEBData.cxx
@@ -63,9 +63,10 @@ bool DrawFEBData::analyze(const gallery::Event & ev) {
           continue;
 
         uint32_t mac5 = feb.Mac5();
-        // t0 is ???
-        // t1 is the offset specific for this FEB
-        int64_t t0 = (int64_t)feb.Ts0() - etrig_time;
+
+        // Take the T0 time (time since PPS) reference to to the event trigger
+        // and apply stored cable delay in Coinc field.
+        int64_t t0 = (int64_t)feb.Ts0() - etrig_time + feb.Coinc();
         uint32_t t1 = feb.Ts1();
 
         const auto& adc_arr = feb.ADC();

--- a/UserDev/EventDisplay/python/titus/modules/crt_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/crt_module.py
@@ -22,7 +22,7 @@ from titus.modules import Module
 import titus.drawables as drawables
 
 _SBND_CRT_FEBDATA = 'sbnd::crt::FEBData'
-_CRT_COLORMAP = pg.colormap.get('CET-D8')
+_CRT_COLORMAP = pg.colormap.get('CET-L17')
 # _CRT_COLORMAP.reverse()
 
 
@@ -178,7 +178,7 @@ class CrtHitsItem(pg.GraphicsObject):
             w = coord_max[1] - coord_min[1]
             color = _CRT_COLORMAP.mapToQColor(tfrac)
             painter.setBrush(color)
-            painter.setOpacity(0.5)
+            painter.setOpacity(0.8)
             painter.setPen(color)
             painter.drawRect(QtCore.QRectF(x, y, l, w))
 
@@ -476,7 +476,7 @@ class CrtTimeViewWidget(pg.GraphicsLayoutWidget):
         super().__init__()
         self._time_plot = pg.PlotItem(name="CRT Hit Times")
         self._time_plot.setLabel(axis='left', text='Hits')
-        self._time_plot.setLabel(axis='bottom', text='Time (μs)')
+        self._time_plot.setLabel(axis='bottom', text='Time (ns)')
         self.addItem(self._time_plot)
 
         self._min_time = -30e6


### PR DESCRIPTION
Small updates to CRT raw display.

- Use the coinc field from FEBData to apply cable delay correction. The corresponding PR to the decoder to actually fill this field will be opened today (I have tested it offline). This field was previously filled with 0 so the default behaviour for previously decoded files won't change.
- Change the colour map to something with more colours that show up on black.
- Increase the opacity, again for visibility reasons.
- Correct time units from us to ns.