### PR TITLE
CRT West East Inversion

### DIFF
--- a/UserDev/EventDisplay/python/titus/modules/crt_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/crt_module.py
@@ -380,15 +380,15 @@ class CrtViewWidget(pg.GraphicsLayoutWidget):
                 return -x -600, y
             return x + 1200, y
 
-        left = coord[0] < -380.0
-        right = coord[0] > 381.3
+        left = coord[0] > -380.0
+        right = coord[0] < 381.3
         if left or right:
             # left or right side: z along xdir, y along ydir (side view)
             x = coord[2]
             y = coord[1]
             if coord[0] < 0: 
-                return x, -y - 800
-            return x, y + 800
+                return x, y + 800
+            return x, -y - 800
         print('invalid point', coord)
 
 


### PR DESCRIPTION
The SBND Left Hand Rule strikes again!

SBND `x` runs from negative in the east (beam right) to positive in the west (beam left). This ensures that the east & west walls are visualised on the correct sides of the TITUS evd.

I've checked the other walls are all located where I expect them, and a few modules within them to make sure up & down, left & right are consistent within them.