### PR TITLE
Revert "CRT West East Inversion"

### DIFF
--- a/UserDev/EventDisplay/python/titus/modules/crt_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/crt_module.py
@@ -380,15 +380,15 @@ class CrtViewWidget(pg.GraphicsLayoutWidget):
                 return -x -600, y
             return x + 1200, y
 
-        left = coord[0] > -380.0
-        right = coord[0] < 381.3
+        left = coord[0] < -380.0
+        right = coord[0] > 381.3
         if left or right:
             # left or right side: z along xdir, y along ydir (side view)
             x = coord[2]
             y = coord[1]
             if coord[0] < 0: 
-                return x, y + 800
-            return x, -y - 800
+                return x, -y - 800
+            return x, y + 800
         print('Warning: Got invalid point when trying to convert to CRT view ', coord)
 
 


### PR DESCRIPTION
Reverts TITUS-EVD/gallery-framework#47

We never actualy reverted this after we realised it was a gdml issue right?

It has been fixed in the gdml since: SBNSoftware/sbndcode#499