### PR TITLE
Feature/twester multi opdetwaveform

### DIFF
--- a/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
+++ b/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
@@ -93,11 +93,13 @@ namespace evd {
     int _n_time_ticks;
     int _n_frames = 1;
     double _time_offset = 0;
+    const int _n_size_reduction = 10;
+    const int _n_max_chs = 360;
 
     std::string _producer;
 
     // sets up the _wvf_data data object
-    void initDataHolder();
+    void initDataHolder(int, int);
 
     const geo::GeometryCore&               _geo_service;
     const detinfo::DetectorPropertiesData& _det_prop;

--- a/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
+++ b/UserDev/EventDisplay/RawViewer/DrawOpDetWaveform.h
@@ -81,6 +81,7 @@ namespace evd {
 
     void set_n_frames(int n) {_n_frames = n;}
     void set_time_offset(double t) {_time_offset = t;}
+    void set_size_reduction(int n) { _n_size_reduction = std::max(1, n); }
 
 
   protected:
@@ -93,7 +94,7 @@ namespace evd {
     int _n_time_ticks;
     int _n_frames = 1;
     double _time_offset = 0;
-    const int _n_size_reduction = 10;
+    int _n_size_reduction = 10;
     const int _n_max_chs = 360;
 
     std::string _producer;

--- a/UserDev/EventDisplay/python/titus/drawables/opdetwaveform.py
+++ b/UserDev/EventDisplay/python/titus/drawables/opdetwaveform.py
@@ -19,6 +19,9 @@ class OpDetWaveform(Drawable):
         self._process.initialize()
         self._process.setInput(self._producer_name)
 
+    def set_compression_factor(self, x: int):
+        self._process.set_size_reduction(x)
+
     def set_producer(self, producer):
         """ override to call setInput instead of setProducer """
         self._producer_name = producer

--- a/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
+++ b/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
@@ -51,7 +51,7 @@ class geoBase(object):
         self._opdet_x = [0]
         self._opdet_y = [0]
         self._opdet_name = ['pmt']
-        self._opdet_default = -9999
+        self._opdet_default = np.nan
         self._n_optical_frames = 1
         self._n_optical_offset = 0
         self._plane_mix = {}
@@ -505,7 +505,7 @@ class sbnd(Geometry):
         self._colorScheme['grayscale'] = color_scheme
 
         self._n_optical_frames = 3
-        self._n_optical_offset = 1501 # 1250
+        self._n_optical_offset = 0 # 1250
 
         self._offset = []
         for v in range(0, self._nViews):

--- a/UserDev/EventDisplay/python/titus/modules/opdet_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/opdet_module.py
@@ -55,7 +55,7 @@ class OpDetModule(Module):
     def init_ui(self):
         # Waveform View
         wfv_layout = QtWidgets.QHBoxLayout()
-        self._wf_view = waveform_view(self._gm.current_geom)
+        self._wf_view = waveform_view(self._gm.current_geom, self._lsm.det_clock_service)
         self._wf_view.timeWindowChanged.connect(self.time_range_wf_worker)
 
         name = VerticalLabel('Waveform Viewer')
@@ -401,21 +401,25 @@ class OpDetModule(Module):
         '''
         OpDet display shows raw waveform data
         '''
-        self._wf_view.drawOpDetWvf(data) # ???
-        if self._show_raw_btn.isChecked():
+        if not self._show_raw_btn.isChecked():
+            return
+        
+        result = parse_opdetwaveforms(data, self._gm.current_geom, self._lsm.det_clock_service)
 
-            max_scale = -1e12
-            min_scale = 1e12
+        self._wf_view.drawOpDetWvf(result)
 
-            for p in self._pmts:
-                min_sc, max_sc = p.set_raw_data(data)
-                max_scale = max(max_scale, max_sc)
-                min_scale = min(min_scale, min_sc)
+        max_scale = -1e12
+        min_scale = 1e12
 
-            for p in self._pmts:
-                p.show_raw_data(min_scale, max_scale, self._selected_ch)
+        for p in self._pmts:
+            min_sc, max_sc = p.set_raw_data(result)
+            max_scale = max(max_scale, max_sc)
+            min_scale = min(min_scale, min_sc)
 
-            # TODO: do the same for arapucas
+        for p in self._pmts:
+            p.show_raw_data(min_scale, max_scale, self._selected_ch)
+
+        # TODO: do the same for arapucas
 
 
     def setFlashesForPlane(self, p, flashes):
@@ -461,10 +465,11 @@ class waveform_view(pg.GraphicsLayoutWidget):
 
     timeWindowChanged = QtCore.pyqtSignal(tuple)
     
-    def __init__(self, geometry, plane=-1):
+    def __init__(self, geometry, clock_service, plane=-1):
         super(waveform_view, self).__init__(border=None)
 
         self._geometry = geometry
+        self._clock_service = clock_service
 
         self._data = None
 
@@ -472,7 +477,7 @@ class waveform_view(pg.GraphicsLayoutWidget):
 
         self._wf_plot = pg.PlotItem(name="OpDetWaveform")
         self._wf_plot.setLabel(axis='left', text='ADC')
-        self._wf_plot.setLabel(axis='bottom', text='Ticks')
+        self._wf_plot.setLabel(axis='bottom', text='Time (us)')
         self.addItem(self._wf_plot)
 
 
@@ -481,15 +486,13 @@ class waveform_view(pg.GraphicsLayoutWidget):
         self._wf_plot.addItem(self._time_window)
 
 
-
     def getWidget(self):
         return self._widget, self._layout
 
 
-
-    def drawOpDetWvf(self, data, offset=100):
+    def drawOpDetWvf(self, data):
+        """Update member variables needed to properly draw waveforms."""
         self._data = data
-
 
         self._wf_plot.autoRange()
 
@@ -502,23 +505,9 @@ class waveform_view(pg.GraphicsLayoutWidget):
             return
 
         self._wf_plot.clear()
-
-        # n_time_ticks = self._geometry.getDetectorClocks().OpticalClock().FrameTicks() * self._geometry.nOpticalFrames()
-        data_y = self._data[ch,:] 
-        ticks = len(data_y)
-        data_x = np.linspace(0, ticks - 1, ticks)
-        if data_y[0] == self._geometry.opdetDefaultValue():
-            return
-
-        # Remove the dafault values from the entries to be plotted
-
-        # self._wf_plot.plot(x=data_x, y=data_y, connect=False, symbol='o')
-        self._wf_plot.plot(x=data_x, y=data_y)
+        self._wf_plot.plot(x=self._data[ch]['time'], y=self._data[ch]['adc'])
         self._wf_plot.addItem(self._time_window)
-
         self._wf_plot.autoRange()
-
-
 
 
 class flash_time_view(pg.GraphicsLayoutWidget):
@@ -577,3 +566,53 @@ class flash_time_view(pg.GraphicsLayoutWidget):
         
         self._time_plot.addItem(self._time_window)
         self._time_plot.autoRange()
+
+
+def parse_opdetwaveforms(data, geometry, clock_service):
+    """Get waveforms & times from raw data returned by DrawOpDetWaveform."""
+    # unpack variable number of waveforms
+    n_waveforms = int(data[0])
+    compression_factor = int(data[1])
+
+    # waveform data follows first two elements. each waveform separated by
+    # a NaN. remove the last element (empty) after the split and then the
+    # leading NaN from each waveform
+    data = data[2:]
+    wvfm_breaks = np.where(np.isnan(data))[0]
+    wvfms = np.split(data, wvfm_breaks)[:-1]
+    for i in range(len(wvfms)):
+        wvfms[i] = wvfms[i][~np.isnan(wvfms[i])]
+
+    # result is a dict like
+    # channel: {'time': [t1, t2, ...], 'adc': [a1, a2, a3, ...]}
+    tick_period = clock_service.DataForJob().OpticalClock().TickPeriod()
+    result = {}
+    for w in wvfms:
+        ch = int(w[0])
+        offset = w[1]
+        wvfm = w[2:]
+
+        if wvfm[0] == geometry.opdetDefaultValue():
+            continue
+
+        ticks = len(wvfm)
+        # extra element for trailing NaN. The NaN prevents pyqtgraph from
+        # connecting waveform lines
+        xs = np.arange(0, ticks + 1, dtype=float)
+        xs *= compression_factor
+
+        # tick to timestamp
+        xs *= tick_period
+        xs += offset 
+
+        # TODO: Lots of appends. These create copies so would be better to
+        # pre-allocate somehow
+        xs[-1] = np.nan
+        wvfm = np.append(wvfm, np.nan)
+        try:
+            result[ch]['time'] = np.append(result[ch]['time'], xs)
+            result[ch]['adc'] = np.append(result[ch]['adc'], wvfm)
+        except KeyError:
+            result[ch] = {'time': xs, 'adc': wvfm}
+
+    return result

--- a/UserDev/EventDisplay/python/titus/modules/opdet_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/opdet_module.py
@@ -473,7 +473,7 @@ class waveform_view(pg.GraphicsLayoutWidget):
 
         self._data = None
 
-        self._time_range = [1500, 2300]
+        self._time_range = [-1500, 1500]
 
         self._wf_plot = pg.PlotItem(name="OpDetWaveform")
         self._wf_plot.setLabel(axis='left', text='ADC')


### PR DESCRIPTION
This PR updates TITUS to support drawing multiple OpDetWaveforms for each channel in the optical view. It consists of a re-factoring of the array structure returned by DrawOpDetWaveform.cxx and corresponding updates in the opdet_module.py Python module. We also introduce a settings page for the optical view that contains a user-adjustable setting to compress the OpDetWaveforms by a fixed factor, which can improve performance.