### PR TITLE
Hotfix/variable opdet waveform

### DIFF
--- a/UserDev/EventDisplay/python/titus/gui/optical_elements.py
+++ b/UserDev/EventDisplay/python/titus/gui/optical_elements.py
@@ -205,8 +205,11 @@ class OpticalElements(pg.ScatterPlotItem):
 
         for element in self._opdet_circles:
             ch = element['data']['id']
-            data_x = self._data[ch]['time']
-            data_y = self._data[ch]['adc']
+            try:
+                data_x = self._data[ch]['time']
+                data_y = self._data[ch]['adc']
+            except KeyError:
+                continue
 
             if len(data_y) == 0:
                 continue

--- a/UserDev/EventDisplay/python/titus/modules/opdet_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/opdet_module.py
@@ -628,6 +628,9 @@ def parse_opdetwaveforms(data, geometry, clock_service):
     # a NaN. remove the last element (empty) after the split and then the
     # leading NaN from each waveform
     data = data[2:]
+    if len(data) == 0:
+        return {}
+
     wvfm_breaks = np.where(np.isnan(data))[0]
     wvfms = np.split(data, wvfm_breaks)[:-1]
     for i in range(len(wvfms)):
@@ -640,7 +643,8 @@ def parse_opdetwaveforms(data, geometry, clock_service):
     for w in wvfms:
         ch = int(w[0])
         offset = w[1]
-        wvfm = w[2:]
+        # remove trailing zeros
+        wvfm = np.trim_zeros(w[2:], trim='b')
 
         if wvfm[0] == geometry.opdetDefaultValue():
             continue


### PR DESCRIPTION
This PR modifies both the opdetwaveform drawer and the TITUS opdet module to support drawing multiple variable-length opdetwaveforms per channel. It also fixes a Python KeyError when attempting to draw timing waveforms. These are also opdetwaveform products but do not have valid channel numbers, and so aren't returned by the opdetwaveform drawer.