### PR TITLE
MCTruth drawing with multiple neutrino interactions

### DIFF
--- a/UserDev/EventDisplay/RecoViewer/DrawMCTruth.cxx
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTruth.cxx
@@ -43,6 +43,7 @@ bool DrawMCTruth::analyze(const gallery::Event & ev) {
       mct._vertex = vtx;
       mct._nu_pdg = truth.GetNeutrino().Nu().PdgCode();
       mct._int_mode = truth.GetNeutrino().Mode();
+      mct._ccnc = truth.GetNeutrino().CCNC();
 
 
       std::vector<int> pdgs;

--- a/UserDev/EventDisplay/RecoViewer/DrawMCTruth.h
+++ b/UserDev/EventDisplay/RecoViewer/DrawMCTruth.h
@@ -36,6 +36,7 @@ public:
   const int                 &nu_pdg() { return _nu_pdg; }
   const float               &nu_energy() { return _nu_energy; }
   const int                 &int_mode() { return _int_mode; }
+  const int                 &ccnc() { return _ccnc; }
   const std::vector<double> &vertex() { return _vertex; }
   const float               &nu_time() { return _nu_time; }
 
@@ -50,6 +51,7 @@ protected:
   std::vector<double> _vertex;      // Vertex of neutrino (if neutrino origin)
   float _nu_time = -9999;           // time of the neutrino (if neutrino origin)
   int _int_mode = -9999;            // interaction (if neutrino origin)
+  int _ccnc = -9999;                // 0: CC, 1: NC (if neutrino origin)
 
   std::vector<int> _finalstate_pdg;      // final state particle pdg (if neutrino origin)
   std::vector<float> _finalstate_energy; // final state particle energy (if neutrino origin)

--- a/UserDev/EventDisplay/python/titus/drawables/mctrack.py
+++ b/UserDev/EventDisplay/python/titus/drawables/mctrack.py
@@ -32,11 +32,20 @@ class MCTrack(Drawable):
                     x = pair.first / self._geom.wire2cm()
                     y = pair.second / self._geom.time2cm()
 
-                    # If odd TPC, shift this piece of the track up
-                    if track.tpc()[i] % 2:
-                        y += 2 * self._geom.triggerOffset()
+                    if track.tpc()[i] == 1:
+                        # flip
+                        y = self._geom.tRange() - y
+                        # move up
+                        y += self._geom.tRange()
+                        # add cathode gap
                         y += self._geom.cathodeGap()
 
+                    # # If odd TPC, shift this piece of the track up
+                    # if track.tpc()[i] % 2:
+                    #     y += 2 * self._geom.triggerOffset()
+                    #     y += self._geom.cathodeGap()
+
+                    print(f'Track {i}, {x}, {y}')
                     points.append(QtCore.QPointF(x, y))
 
                 if len(points) == 0:

--- a/UserDev/EventDisplay/python/titus/drawables/mctruth.py
+++ b/UserDev/EventDisplay/python/titus/drawables/mctruth.py
@@ -90,6 +90,9 @@ class MCTruth(Drawable):
 
         vertex = mct.vertex()
 
+        if not len(vertex):
+            return
+
         for _, view in self._module._wire_views.items():
             self._drawnObjects.append([])
 

--- a/UserDev/EventDisplay/python/titus/drawables/track.py
+++ b/UserDev/EventDisplay/python/titus/drawables/track.py
@@ -44,7 +44,6 @@ class Track(Drawable):
         self._product_name = 'track'
         self._process = evd.DrawTrack(geom.getGeometryCore(), geom.getDetectorProperties(), geom.getDetectorClocks())
         self._process._projections_match = geom.projectionsMatch()
-        print('self._process._projections_match?', self._process._projections_match)
         self._n_planes = geom.nPlanes() * geom.nTPCs() * geom.nCryos()
         self._geom = geom
         self._module = tpc_module

--- a/UserDev/EventDisplay/python/titus/modules/tpc_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/tpc_module.py
@@ -556,6 +556,7 @@ class TpcModule(Module):
         frame.setLayout(main_layout)
         self._mctruth_dock.setWidget(frame)
 
+        self._mctruth_dropdown = QtWidgets.QComboBox()
         self._mctruth_text1 = QtWidgets.QLabel("Some text 1")
         self._mctruth_text2 = QtWidgets.QLabel("Some text 2")
         self._show_vertex = QtWidgets.QCheckBox("Show Neutrino Vertex")
@@ -565,6 +566,7 @@ class TpcModule(Module):
 
         text_layout = QtWidgets.QVBoxLayout()
         text_layout.addStretch()
+        text_layout.addWidget(self._mctruth_dropdown)
         text_layout.addWidget(self._mctruth_text1)
         text_layout.addWidget(self._mctruth_text2)
         text_layout.addWidget(self._show_vertex)


### PR DESCRIPTION
Add ability to select neutrino in MCTruth if multiple neutrino interactions are present in one event.
Before, only the firt neutrino was shown.

<img width="289" alt="image" src="https://github.com/user-attachments/assets/9a561434-eaf9-47c7-bd9f-673b152c3743" />

![image](https://github.com/user-attachments/assets/681d7653-04ea-4b0a-9e5d-187d5e1c2351)
